### PR TITLE
Fix: shop selection cursor visible on all options on open

### DIFF
--- a/Assets/Scripts/Scenes/Shop/ShopController.cs
+++ b/Assets/Scripts/Scenes/Shop/ShopController.cs
@@ -28,6 +28,21 @@ namespace Scenes.Shop
         public Sprite coinSprite;
         public Text headingText; // <-- add this
 
+        /// <summary>
+        /// Returns the pointer text for an item at the given index ("> " if selected, "  " otherwise).
+        /// Used by UpdatePointers and by tests.
+        /// </summary>
+        public static string GetPointerTextForIndex(int index, int selectedIndex)
+        {
+            return index == selectedIndex ? "> " : "  ";
+        }
+
+        private void Awake()
+        {
+            if (items != null && items.Length > 0)
+                UpdatePointers();
+        }
+
         private void Start()
         {
             playerCount = PlayerPrefs.GetInt("Players", 2);
@@ -96,9 +111,12 @@ namespace Scenes.Shop
 
         void UpdatePointers()
         {
+            if (items == null)
+                return;
             for (int i = 0; i < items.Length; i++)
             {
-                items[i].pointerText.text = (i == selectedIndex) ? "> " : "  ";
+                if (items[i].pointerText != null)
+                    items[i].pointerText.text = GetPointerTextForIndex(i, selectedIndex);
             }
         }
 

--- a/Assets/Tests/EditMode/ShopControllerTests.cs
+++ b/Assets/Tests/EditMode/ShopControllerTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using Scenes.Shop;
+
+public class ShopControllerTests
+{
+    [Test]
+    public void GetPointerTextForIndex_WhenSelected_ReturnsPointer()
+    {
+        Assert.That(ShopController.GetPointerTextForIndex(0, 0), Is.EqualTo("> "));
+        Assert.That(ShopController.GetPointerTextForIndex(2, 2), Is.EqualTo("> "));
+    }
+
+    [Test]
+    public void GetPointerTextForIndex_WhenNotSelected_ReturnsSpaces()
+    {
+        Assert.That(ShopController.GetPointerTextForIndex(1, 0), Is.EqualTo("  "));
+        Assert.That(ShopController.GetPointerTextForIndex(0, 1), Is.EqualTo("  "));
+    }
+
+    [Test]
+    public void GetPointerTextForIndex_OnlyOneIndexShowsPointerForGivenSelectedIndex()
+    {
+        int selectedIndex = 2;
+        int itemCount = 5;
+        int pointerCount = 0;
+        for (int i = 0; i < itemCount; i++)
+        {
+            string text = ShopController.GetPointerTextForIndex(i, selectedIndex);
+            if (text == "> ")
+                pointerCount++;
+        }
+        Assert.That(
+            pointerCount,
+            Is.EqualTo(1),
+            "Exactly one option should show the pointer for a given selectedIndex"
+        );
+    }
+}

--- a/Assets/Tests/TESTING.md
+++ b/Assets/Tests/TESTING.md
@@ -13,6 +13,7 @@ EditMode tests live in **EditMode/**.
 | `Core/SessionManager` | EditMode/SessionManagerTests.cs |
 | `Scenes/Shop/ShopItemTypeExtensions`, `ShopItemType` | EditMode/ShopItemExtensionsTests.cs |
 | `Scenes/Shop/ShopPurchaseLogic` | EditMode/ShopPurchaseLogicTests.cs |
+| `Scenes/Shop/ShopController` (GetPointerTextForIndex) | EditMode/ShopControllerTests.cs |
 | `Scenes/Arena/ArenaLogic`, `WinStateResult`, `PlayerSlot`, `WinOutcome` | EditMode/PlayerSetupTests.cs, EditMode/WinStateTests.cs |
 | `Utilities/Singleton` | EditMode/SingletonTests.cs |
 | `Core/SceneFlowManager` (ShouldAdvanceOnAnyInput) | EditMode/SceneFlowManagerTests.cs |
@@ -30,7 +31,7 @@ EditMode tests live in **EditMode/**.
 No dedicated unit tests; covered by integration, PlayMode, or manual testing.
 
 - **Core:** AudioController, ContinueOnAnyInput, AnimatedSpriteRenderer
-- **Scenes/Shop:** ShopController (logic in ShopPurchaseLogic is unit-tested)
+- **Scenes/Shop:** ShopController (pointer logic and ShopPurchaseLogic are unit-tested)
 - **Scenes/Arena:** GameManager, MapSelector, ArenaShrinker, ItemPickup, Destructible, Indestructible, Bomb/Explosion, Bomb/RemoteBombController
 - **Scenes/Arena/Player:** PlayerController, DebugItemSpawner, PlayerDebugPlayerPrefs, Abilities (Ghost, Protection, Superman)
 - **Scenes:** MainMenuController, StandingsController, WheelController, OversController (GameOver)


### PR DESCRIPTION
Fixes #5

## Problem

When the shop opens, the selection cursor (">") appeared on every option instead of only the selected one.

## Fix

- Call **UpdatePointers() from Awake()** so the correct ">"/"  " state is applied before the first frame (avoids showing prefab default ">" on all rows).
- In **UpdatePointers()**, add null checks for `items` and `items[i].pointerText` to avoid NullReferenceException.
- Add **GetPointerTextForIndex(index, selectedIndex)** static helper so pointer logic is testable and used by UpdatePointers().

## Tests

- New EditMode tests in **ShopControllerTests.cs** for GetPointerTextForIndex: selected index returns "> ", others return "  "; exactly one pointer for a given selectedIndex.
- TESTING.md updated to list ShopController pointer tests.