### PR TITLE
Fix: shop purchases persist to arena; coins and upgrades in SessionManager

### DIFF
--- a/Assets/Scripts/Core/SessionManager.cs
+++ b/Assets/Scripts/Core/SessionManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Scenes.Shop;
 using Utilities;
 
@@ -11,10 +11,14 @@ namespace Core
         public Dictionary<int, Dictionary<ShopItemType, int>> PlayerUpgrades =
             new Dictionary<int, Dictionary<ShopItemType, int>>();
 
+        /// <summary>Session-only coin count per player (not in PlayerPrefs).</summary>
+        public Dictionary<int, int> PlayerCoins = new Dictionary<int, int>();
+
         // 3. Setup/Cleanup Method
         public void Initialize(int playerCount)
         {
             PlayerUpgrades.Clear();
+            PlayerCoins.Clear();
             for (int id = 1; id <= playerCount; id++)
             {
                 // Initialize each player with a dictionary to store their upgrades
@@ -26,7 +30,25 @@ namespace Core
                     if (type != ShopItemType.Exit)
                         PlayerUpgrades[id][type] = 0;
                 }
+                PlayerCoins[id] = 0;
             }
+        }
+
+        public int GetCoins(int playerId)
+        {
+            return PlayerCoins.TryGetValue(playerId, out int c) ? c : 0;
+        }
+
+        public void SetCoins(int playerId, int value)
+        {
+            if (PlayerCoins.ContainsKey(playerId))
+                PlayerCoins[playerId] = value;
+        }
+
+        public void AddCoins(int playerId, int amount)
+        {
+            if (PlayerCoins.ContainsKey(playerId))
+                PlayerCoins[playerId] += amount;
         }
 
         // 4. Accessor/Mutator Method

--- a/Assets/Scripts/Scenes/Arena/Bomb/BombController.cs
+++ b/Assets/Scripts/Scenes/Arena/Bomb/BombController.cs
@@ -249,6 +249,8 @@ namespace Scenes.Arena.Bomb
 
         public void ApplyUpgrades(int playerId)
         {
+            if (Core.SessionManager.Instance == null)
+                return;
             // Reset to base values first
             bombsRemaining = bombAmount;
             timeBomb = false;

--- a/Assets/Scripts/Scenes/Arena/GameManager.cs
+++ b/Assets/Scripts/Scenes/Arena/GameManager.cs
@@ -39,10 +39,14 @@ namespace Scenes.Arena
             int playerCount = PlayerPrefs.GetInt("Players", 2);
 
             // Ensure SessionManager has structure for this game (e.g. first round from menu); do not re-initialize when returning from shop
+            // SessionManager may not exist in the Game scene (e.g. Menu→Countdown→Game); if null, skip so SetupPlayers still runs and only N players show
             if (
-                SessionManager.Instance.PlayerUpgrades == null
-                || SessionManager.Instance.PlayerUpgrades.Count == 0
-                || !SessionManager.Instance.PlayerUpgrades.ContainsKey(1)
+                SessionManager.Instance != null
+                && (
+                    SessionManager.Instance.PlayerUpgrades == null
+                    || SessionManager.Instance.PlayerUpgrades.Count == 0
+                    || !SessionManager.Instance.PlayerUpgrades.ContainsKey(1)
+                )
             )
             {
                 SessionManager.Instance.Initialize(playerCount);
@@ -50,11 +54,11 @@ namespace Scenes.Arena
 
             SetupPlayers(playerCount);
 
-            // 🔹 Force upgrades to be reapplied every new game round
+            // 🔹 Force upgrades to be reapplied every new game round (only when SessionManager exists)
             foreach (var p in players)
             {
                 var pc = p.GetComponent<PlayerController>();
-                if (pc != null)
+                if (pc != null && SessionManager.Instance != null)
                     pc.ApplyUpgrades();
             }
 
@@ -166,6 +170,7 @@ namespace Scenes.Arena
 
         private void Standings()
         {
+            SyncCoinsToSessionManager();
             SceneFlowManager.I.GoTo(FlowState.Standings);
         }
 
@@ -174,7 +179,7 @@ namespace Scenes.Arena
         private void EndGame()
         {
             Debug.Log("[GameManager] Timer expired → game over!");
-            // Option A: go directly to Standings
+            SyncCoinsToSessionManager();
             SceneFlowManager.I.GoTo(FlowState.Standings);
         }
 
@@ -186,14 +191,39 @@ namespace Scenes.Arena
 
         void GivePlayersStartCoin()
         {
-            foreach (var p in players)
+            if (SessionManager.Instance == null)
+                return;
+            int count = PlayerPrefs.GetInt("Players", 2);
+            var setup = ArenaLogic.GetPlayerSetup(count);
+            foreach (var (slot, playerId) in setup)
             {
-                var movement = p.GetComponent<PlayerController>();
+                var playerObj = GetPlayerObject(slot);
+                if (playerObj == null)
+                    continue;
+                var movement = playerObj.GetComponent<PlayerController>();
                 if (movement != null)
                 {
-                    movement.coins += 1;
-                    Debug.Log($"{p.name} given 1 start coin (total: {movement.coins})");
+                    SessionManager.Instance.AddCoins(playerId, 1);
+                    movement.coins = SessionManager.Instance.GetCoins(playerId);
+                    Debug.Log(
+                        $"{playerObj.name} (Player {playerId}) given 1 start coin (total: {movement.coins})"
+                    );
                 }
+            }
+        }
+
+        /// <summary>Push each active player's in-memory coins to SessionManager so Shop sees current totals.</summary>
+        void SyncCoinsToSessionManager()
+        {
+            if (SessionManager.Instance == null || players == null)
+                return;
+            foreach (var p in players)
+            {
+                if (p == null || !p.activeInHierarchy)
+                    continue;
+                var pc = p.GetComponent<PlayerController>();
+                if (pc != null)
+                    SessionManager.Instance.SetCoins(pc.playerId, pc.coins);
             }
         }
 

--- a/Assets/Scripts/Scenes/Arena/Player/Abilities/Ghost.cs
+++ b/Assets/Scripts/Scenes/Arena/Player/Abilities/Ghost.cs
@@ -42,6 +42,11 @@ namespace Scenes.Arena.Player.Abilities
 
         void ApplyUpgrades()
         {
+            if (SessionManager.Instance == null)
+            {
+                active = false;
+                return;
+            }
             var playerId = pc.playerId;
             active = SessionManager.Instance.GetUpgradeLevel(playerId, ShopItemType.Ghost) == 1;
             Debug.Log($"[PlayerController] Player {playerId} ghost applied.");

--- a/Assets/Scripts/Scenes/Arena/Player/Abilities/Protection.cs
+++ b/Assets/Scripts/Scenes/Arena/Player/Abilities/Protection.cs
@@ -40,6 +40,11 @@ namespace Scenes.Arena.Player.Abilities
 
         void ApplyUpgrades()
         {
+            if (SessionManager.Instance == null)
+            {
+                active = false;
+                return;
+            }
             var playerId = pc.playerId;
             active =
                 SessionManager.Instance.GetUpgradeLevel(playerId, ShopItemType.Protection) == 1;

--- a/Assets/Scripts/Scenes/Arena/Player/Abilities/Superman.cs
+++ b/Assets/Scripts/Scenes/Arena/Player/Abilities/Superman.cs
@@ -43,6 +43,11 @@ namespace Scenes.Arena.Player.Abilities
 
         private void ApplyUpgrades()
         {
+            if (SessionManager.Instance == null)
+            {
+                active = false;
+                return;
+            }
             var playerId = pc.playerId;
             active = SessionManager.Instance.GetUpgradeLevel(playerId, ShopItemType.Superman) == 1;
             Debug.Log($"[PlayerController] Player {playerId} superman applied.");

--- a/Assets/Scripts/Scenes/Arena/Player/PlayerController.cs
+++ b/Assets/Scripts/Scenes/Arena/Player/PlayerController.cs
@@ -182,6 +182,9 @@ namespace Scenes.Arena.Player
                 Debug.LogError("[PlayerController] Cannot apply upgrades: Player ID is invalid.");
                 return;
             }
+            // SessionManager may not exist in this scene (e.g. Game before Shop); treat as no upgrades
+            if (SessionManager.Instance == null)
+                return;
 
             // Reset player stats that are affected by stackable upgrades (like speed, bomb stats)
             // NOTE: You'll need to reset other stats here if they are affected by stackable upgrades.
@@ -189,8 +192,9 @@ namespace Scenes.Arena.Player
             // and this function is called on start/enable.
             speed = 5f;
 
-            // Coins
-            coins = PlayerPrefs.GetInt($"Player{playerId}_Coins", 0);
+            // Coins (session-only, from SessionManager)
+            coins =
+                SessionManager.Instance != null ? SessionManager.Instance.GetCoins(playerId) : 0;
 
             // ---------------------------------------------------------------------------------
             // 🔁 STACKABLE UPGRADES (PowerUp, ExtraBomb, SpeedUp)
@@ -322,8 +326,12 @@ namespace Scenes.Arena.Player
 
         public void AddCoin()
         {
-            coins++;
-            PlayerPrefs.SetInt($"Player{playerId}_Coins", coins);
+            if (SessionManager.Instance != null)
+                SessionManager.Instance.AddCoins(playerId, 1);
+            coins =
+                SessionManager.Instance != null
+                    ? SessionManager.Instance.GetCoins(playerId)
+                    : coins + 1;
             Debug.Log($"[PlayerController] Player {playerId} coins increased to {coins}");
         }
 

--- a/Assets/Scripts/Scenes/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/Scenes/MainMenu/MainMenuController.cs
@@ -132,15 +132,16 @@ namespace Scenes.MainMenu
             PlayerPrefs.SetInt("NormalLevel", normalLevel ? 1 : 0);
             PlayerPrefs.SetInt("Gambling", gambling ? 1 : 0);
 
-            // Reset per-player progress (wins, coins; upgrades are in SessionManager)
+            // Reset per-player progress (wins in PlayerPrefs; coins/upgrades in SessionManager)
             for (int i = 1; i <= 5; i++)
             {
                 PlayerPrefs.SetInt($"Player{i}_Wins", 0);
-                PlayerPrefs.SetInt($"Player{i}_Coins", 0);
             }
 
             // Reset in-memory upgrade state for new game (SessionManager is source of truth for upgrades)
-            SessionManager.Instance.Initialize(players);
+            // SessionManager may not exist in the Menu scene; it is created in Shop/Game. Guard so we don't throw and block SignalMenuStart().
+            if (SessionManager.Instance != null)
+                SessionManager.Instance.Initialize(players);
 
             PlayerPrefs.Save();
         }

--- a/Assets/Scripts/Scenes/Shop/ShopController.cs
+++ b/Assets/Scripts/Scenes/Shop/ShopController.cs
@@ -142,7 +142,8 @@ namespace Scenes.Shop
                 Destroy(child.gameObject);
 
             int playerId = currentPlayer;
-            int coins = PlayerPrefs.GetInt($"Player{playerId}_Coins", 0);
+            int coins =
+                SessionManager.Instance != null ? SessionManager.Instance.GetCoins(playerId) : 0;
 
             for (int i = 0; i < coins; i++)
             {
@@ -178,19 +179,20 @@ namespace Scenes.Shop
                 return;
             }
 
-            // Normal purchase flow
+            // Normal purchase flow (coins in SessionManager)
             int playerId = currentPlayer;
-            int coins = PlayerPrefs.GetInt($"Player{playerId}_Coins", 0);
+            int coins =
+                SessionManager.Instance != null ? SessionManager.Instance.GetCoins(playerId) : 0;
 
             if (ShopPurchaseLogic.CanAfford(coins, item.cost))
             {
                 coins -= item.cost;
-                PlayerPrefs.SetInt($"Player{playerId}_Coins", coins);
+                if (SessionManager.Instance != null)
+                    SessionManager.Instance.SetCoins(playerId, coins);
                 AudioController.I.PlayBuy();
 
                 ApplyUpgrade(playerId, item.type);
 
-                PlayerPrefs.Save();
                 Debug.Log($"Player {playerId} bought {item.name}!");
             }
             else

--- a/Assets/Scripts/Scenes/WheelOFortune/WheelController.cs
+++ b/Assets/Scripts/Scenes/WheelOFortune/WheelController.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Core;
 using UnityEngine;
 using UnityEngine.UI;
@@ -105,13 +105,14 @@ namespace Scenes.WheelOFortune
             // Final reward sound
             AudioController.I.PlayChaChing();
 
-            // Reward selected player with a coin
+            // Reward selected player with a coin (session-only, in SessionManager)
             int winningPlayer = stopIndex + 1;
-            int coins = PlayerPrefs.GetInt($"Player{winningPlayer}_Coins", 0);
-            PlayerPrefs.SetInt($"Player{winningPlayer}_Coins", coins + 1);
-            PlayerPrefs.Save();
-
-            Debug.Log($"Player {winningPlayer} wins a coin! Total: {coins + 1}");
+            if (SessionManager.Instance != null)
+            {
+                SessionManager.Instance.AddCoins(winningPlayer, 1);
+                int total = SessionManager.Instance.GetCoins(winningPlayer);
+                Debug.Log($"Player {winningPlayer} wins a coin! Total: {total}");
+            }
 
             // Wait before moving on
             yield return new WaitForSeconds(postSpinDelay);

--- a/Assets/Tests/EditMode/SessionManagerTests.cs
+++ b/Assets/Tests/EditMode/SessionManagerTests.cs
@@ -88,4 +88,58 @@ public class SessionManagerTests
         Assert.That(_sessionManager.PlayerUpgrades.ContainsKey(2), Is.True);
         Assert.That(_sessionManager.PlayerUpgrades.ContainsKey(3), Is.True);
     }
+
+    [Test]
+    public void Initialize_WithTwoPlayers_AllCoinsZero()
+    {
+        _sessionManager.Initialize(2);
+        Assert.That(_sessionManager.GetCoins(1), Is.EqualTo(0));
+        Assert.That(_sessionManager.GetCoins(2), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetCoins_UnknownPlayer_ReturnsZero()
+    {
+        _sessionManager.Initialize(2);
+        Assert.That(_sessionManager.GetCoins(99), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SetCoins_ThenGetCoins_ReturnsSetValue()
+    {
+        _sessionManager.Initialize(2);
+        _sessionManager.SetCoins(1, 5);
+        _sessionManager.SetCoins(2, 3);
+        Assert.That(_sessionManager.GetCoins(1), Is.EqualTo(5));
+        Assert.That(_sessionManager.GetCoins(2), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void AddCoins_IncreasesTotal()
+    {
+        _sessionManager.Initialize(2);
+        _sessionManager.AddCoins(1, 1);
+        Assert.That(_sessionManager.GetCoins(1), Is.EqualTo(1));
+        _sessionManager.AddCoins(1, 2);
+        Assert.That(_sessionManager.GetCoins(1), Is.EqualTo(3));
+        Assert.That(_sessionManager.GetCoins(2), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SetCoins_UnknownPlayer_DoesNotThrow()
+    {
+        _sessionManager.Initialize(2);
+        Assert.DoesNotThrow(() => _sessionManager.SetCoins(99, 10));
+        Assert.That(_sessionManager.GetCoins(99), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Initialize_ClearsPreviousPlayerCoins()
+    {
+        _sessionManager.Initialize(2);
+        _sessionManager.SetCoins(1, 5);
+        _sessionManager.Initialize(2);
+        Assert.That(_sessionManager.GetCoins(1), Is.EqualTo(0));
+        Assert.That(_sessionManager.GetCoins(2), Is.EqualTo(0));
+    }
 }

--- a/Assets/Tests/EditMode/ShopControllerTests.cs.meta
+++ b/Assets/Tests/EditMode/ShopControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5abc638f7daba114995f1638940fc483

--- a/Assets/Tests/TESTING.md
+++ b/Assets/Tests/TESTING.md
@@ -10,7 +10,7 @@ EditMode tests live in **EditMode/**.
 |-----------|-----------|
 | `Core/SceneNamesConfig` | EditMode/SceneNamesConfigTests.cs |
 | `Core/SceneFlowMapper` | EditMode/SceneFlowMapperTests.cs |
-| `Core/SessionManager` (upgrade state is session-only; shop and arena use it for upgrades) | EditMode/SessionManagerTests.cs |
+| `Core/SessionManager` (upgrades and coins session-only; shop and arena use it) | EditMode/SessionManagerTests.cs |
 | `Scenes/Shop/ShopItemTypeExtensions`, `ShopItemType` | EditMode/ShopItemExtensionsTests.cs |
 | `Scenes/Shop/ShopPurchaseLogic` | EditMode/ShopPurchaseLogicTests.cs |
 | `Scenes/Shop/ShopController` (GetPointerTextForIndex) | EditMode/ShopControllerTests.cs |


### PR DESCRIPTION
Fixes #7

## Problem

1. When buying items in the shop, purchased powerups were not applied to players in the arena.
2. When only 2 players were selected from the main menu, all 5 players were visible in the arena (Standings/Wheel/Shop correctly showed 2).
3. Start money and arena-earned coins did not show correctly in the shop; coin display was inconsistent.
4. User requested upgrades and coins not be stored in PlayerPrefs (reserved for settings like music).

## Design

- **SessionManager** is the single in-memory source for **upgrades** and **coins** for the session. No PlayerPrefs for upgrades or coins; they reset when the game closes.
- **PlayerPrefs** remain for settings (WinsNeeded, Players, Shop, Shrinking, StartMoney, etc.) and per-player **wins**.

## Changes

### SessionManager
- Added **PlayerCoins** dictionary and **GetCoins**, **SetCoins**, **AddCoins**. **Initialize** clears and sets coins to 0 per player.

### Arena / Game flow
- **GameManager**: Guard all SessionManager access so when Instance is null (e.g. Menu→Countdown→Game before Shop), **SetupPlayers** still runs and only the selected player count is shown. **GivePlayersStartCoin** and **SyncCoinsToSessionManager** use SessionManager only (no PlayerPrefs). When leaving the arena, **SyncCoinsToSessionManager** pushes in-memory coins to SessionManager so the shop sees current totals.
- **PlayerController**, **BombController**, **Ghost**, **Protection**, **Superman**: Null-check SessionManager in ApplyUpgrades; **PlayerController** loads coins from SessionManager and **AddCoin** updates SessionManager.

### Shop & Wheel
- **ShopController**: Read/display and deduct coins via SessionManager only.
- **WheelController**: Award coin via **SessionManager.AddCoins**.

### Menu
- **MainMenuController.SavePrefs**: Call **SessionManager.Initialize(players)** when Instance exists (resets upgrades and coins for new game). Removed PlayerPrefs coin reset. Guard SessionManager access so pressing Enter on menu does not throw when SessionManager is not yet created.

### Tests & docs
- **SessionManagerTests**: Added tests for **GetCoins**, **SetCoins**, **AddCoins**, **Initialize** coins and clearing.
- **TESTING.md**: Noted that coins are session-only in SessionManager.
- Code formatted with CSharpier.

## Tests

- EditMode: SessionManager (upgrades and coins), ShopPurchaseLogic, ShopController pointer, SceneFlowManager, WinState, etc.
- PlayMode: PersistentSingleton, CountdownController, BombController.
- CI runs EditMode and PlayMode jobs separately.